### PR TITLE
Prototype headless Codex loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# agent
+# Headless Codex Prototype
+
+Prototype exploring a loop between a placeholder "orchestrator" and the ChatGPT Codex site using a headless browser.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+playwright install
+```
+
+## Usage
+
+```bash
+python codex_loop.py "What is the capital of France?" --cycles 1
+```
+
+The script performs the following simplified cycle:
+
+1. The orchestrator generates a question (currently a stub).
+2. The question is sent to `https://chatgpt.com/codex` using a headless browser.
+3. The response is extracted from the DOM and printed.
+4. The response is fed back into the orchestrator for the next cycle.
+
+The number of cycles can be configured via the `--cycles` flag. LLM integration is left as a TODO.

--- a/codex_loop.py
+++ b/codex_loop.py
@@ -1,0 +1,63 @@
+import argparse
+import asyncio
+from typing import Optional
+
+from playwright.async_api import async_playwright
+
+
+CODEx_URL = "https://chatgpt.com/codex"
+
+
+def orchestrator_llm(prompt: str) -> str:
+    """Placeholder for an orchestrator LLM.
+
+    In a full implementation this function would call an LLM to determine the
+    next action based on the provided prompt. For now it simply echoes the
+    prompt to demonstrate the flow.
+    """
+    return f"Echo: {prompt}"
+
+
+async def ask_codex(question: str) -> str:
+    """Send a question to the Codex site and return the last response text."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page()
+        await page.goto(CODEx_URL)
+
+        # Wait for the text area to be available and submit the question
+        textarea_selector = "textarea"
+        await page.wait_for_selector(textarea_selector)
+        await page.fill(textarea_selector, question)
+        await page.keyboard.press("Enter")
+
+        # Wait for a response to appear in the DOM
+        response_selector = "div.markdown"  # selector for chat response text
+        await page.wait_for_selector(response_selector, timeout=60000)
+        content = await page.locator(response_selector).last.inner_text()
+
+        await browser.close()
+        return content
+
+
+async def run(goal: str, cycles: int) -> None:
+    """Run the orchestrator/agent loop for a given number of cycles."""
+    query: Optional[str] = goal
+    for idx in range(1, cycles + 1):
+        if query is None:
+            break
+        result = await ask_codex(query)
+        print(f"Cycle {idx} result:\n{result}\n")
+        query = orchestrator_llm(result)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Codex headless loop prototype")
+    parser.add_argument("goal", help="Initial user goal or question")
+    parser.add_argument("--cycles", type=int, default=1, help="Number of cycles to run")
+    args = parser.parse_args()
+    asyncio.run(run(args.goal, args.cycles))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+playwright


### PR DESCRIPTION
## Summary
- Prototype `codex_loop.py` for cycling between a placeholder orchestrator and the ChatGPT Codex site using a headless browser.
- Added `requirements.txt` and updated `README` with setup and usage instructions.

## Testing
- `python -m py_compile codex_loop.py`


------
https://chatgpt.com/codex/tasks/task_e_6892590c94b08324823bb2f311a56981