### PR TITLE
Integrate OpenAI completion

### DIFF
--- a/codex_loop.py
+++ b/codex_loop.py
@@ -1,21 +1,28 @@
 import argparse
 import asyncio
+import json
 from typing import Optional
 
 from playwright.async_api import async_playwright
+
+from openai_utils import (
+    openai_configure_api,
+    openai_generate_response,
+    openai_parse_function_call,
+)
 
 
 CODEx_URL = "https://chatgpt.com/codex"
 
 
 def orchestrator_llm(prompt: str) -> str:
-    """Placeholder for an orchestrator LLM.
-
-    In a full implementation this function would call an LLM to determine the
-    next action based on the provided prompt. For now it simply echoes the
-    prompt to demonstrate the flow.
-    """
-    return f"Echo: {prompt}"
+    """Call an LLM to determine the next action based on the prompt."""
+    messages = [{"role": "user", "content": prompt}]
+    response = openai_generate_response(messages)
+    name, parsed = openai_parse_function_call(response)
+    if name:
+        return json.dumps(parsed)
+    return response.choices[0].message.content or ""
 
 
 async def ask_codex(question: str) -> str:
@@ -56,6 +63,7 @@ def main() -> None:
     parser.add_argument("goal", help="Initial user goal or question")
     parser.add_argument("--cycles", type=int, default=1, help="Number of cycles to run")
     args = parser.parse_args()
+    openai_configure_api()
     asyncio.run(run(args.goal, args.cycles))
 
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -1,0 +1,174 @@
+import os
+import sys
+import json
+import logging
+import pprint
+from openai import OpenAI
+
+client = None  # Will be configured later via openai_configure_api
+from typing import Optional, Tuple, Dict, Any, List
+
+# Configure logging for clarity
+logging.basicConfig(
+    level=logging.INFO,
+    stream=sys.stdout,
+    format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+# Define the function schema for flagged_methods.
+FLAGGED_METHODS_FUNCTION_SCHEMA = [
+    {
+        "name": "flagged_methods",
+        "description": "Returns the list of flagged methods from the response. Each entry in the list should be a dictionary with keys: 'method', 'params' (an array of strings), and 'primitive'.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "flagged_methods": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "method": {"type": "string"},
+                            "params": {"type": "array", "items": {"type": "string"}},
+                            "primitive": {"type": "string"},
+                            "description": {"type": "string"},
+                            "chain": {"type": "string"},
+                            "severity": {"type": "string"}
+                        },
+                        "required": ["method", "params", "primitive", "description", "chain", "severity"]
+                    }
+                }
+            },
+            "required": ["flagged_methods"]
+        }
+    }
+]
+
+FLAG_USAGE_FUNCTION_SCHEMA = [
+    {
+        "name": "flag_usage",
+        "description": "Processes flag usage details and returns a dictionary with keys: 'method', 'confidence', and 'files'.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "method": {"type": "string"},
+                "confidence": {"type": "number"},
+                "files": {"type": "array", "items": {"type": "string"}}
+            },
+            "required": ["method", "confidence", "files"]
+        }
+    }
+]
+
+LOG_DATA_FUNCTION_SCHEMA = [
+    {
+        "name": "log_data",
+        "description": (
+            "Returns an array of arbitrary JSON objects supplied by the model. "
+            "The caller’s system prompt defines the expected object structure."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "records": {
+                    "type": "array",
+                    "items": {}
+                }
+            },
+            "required": ["records"]
+        }
+    }
+]
+
+def openai_configure_api(api_key: Optional[str] = None) -> None:
+    """
+    Configures the OpenAI API key.
+    """
+    global client
+    if api_key is None:
+        api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("An API key must be provided either as an argument or via the OPENAI_API_KEY environment variable.")
+    client = OpenAI(api_key=api_key)  # Configure the OpenAI client using the provided API key
+    logging.info("OpenAI API configured successfully.")
+
+
+def openai_generate_response(
+    messages: List[Dict[str, Any]],
+    functions: Optional[List[Dict[str, Any]]] = None,
+    model: str = "o3-mini",  # Change to your desired model
+    function_call: Optional[Any] = "auto"
+) -> Any:
+    """
+    Sends a chat message with an optional function schema and returns the API response.
+    """
+    if functions is None:
+        functions = FLAGGED_METHODS_FUNCTION_SCHEMA
+    logging.info("Sending messages:\n%s", pprint.pformat(messages))
+    response = client.chat.completions.create(model=model,
+    reasoning_effort="high",
+    service_tier="flex",
+    messages=messages,
+    functions=functions,
+    function_call=function_call)
+    logging.info("Received response:\n%s", pprint.pformat(response))
+    return response
+
+def openai_parse_function_call(response: Any) -> Tuple[Optional[str], Optional[Any]]:
+    """
+    Parses the function call details from the API response.
+    Supports both 'flag_usage' and 'flagged_methods' function calls.
+    """
+    try:
+        message = response.choices[0].message
+    except (KeyError, IndexError):
+        logging.info("Unexpected response format:\n%s", pprint.pformat(response))
+        return None, None
+
+    function_call = message.function_call
+    if function_call and getattr(function_call, 'name', None) == "flag_usage":
+        args_str = getattr(function_call, 'arguments', "")
+        usage = {}
+        try:
+            parsed_args = json.loads(args_str) if isinstance(args_str, str) else args_str
+            if isinstance(parsed_args, dict):
+                usage = parsed_args
+        except (json.JSONDecodeError, AttributeError):
+            usage = {}
+        logging.info("Extracted flag_usage: %s", pprint.pformat(usage))
+        return "flag_usage", usage
+    elif function_call and getattr(function_call, 'name', None) == "flagged_methods":
+        args_str = getattr(function_call, 'arguments', "")
+        flagged = []
+        try:
+            parsed_args = json.loads(args_str) if isinstance(args_str, str) else args_str
+            if isinstance(parsed_args, list):
+                flagged = parsed_args
+            elif isinstance(parsed_args, dict) and "flagged_methods" in parsed_args:
+                flagged = parsed_args["flagged_methods"]
+        except (json.JSONDecodeError, AttributeError):
+            flagged = []
+        # Validate that each flagged method dictionary has keys with correct types.
+        for method in flagged:
+            if not isinstance(method.get("params"), list):
+                logging.error("flagged method entry missing or has invalid 'params': %s", method)
+            if not isinstance(method.get("description"), str):
+                logging.error("flagged method entry missing or has invalid 'description': %s", method)
+            if not isinstance(method.get("chain"), str):
+                logging.error("flagged method entry missing or has invalid 'chain': %s", method)
+            if not isinstance(method.get("severity"), str):
+                logging.error("flagged method entry missing or has invalid 'severity': %s", method)
+        logging.info("Extracted flagged_methods: %s", pprint.pformat(flagged))
+        return "flagged_methods", flagged
+
+    elif function_call and getattr(function_call, 'name', None) == "log_data":
+        args_str = function_call.arguments or ""
+        try:
+            parsed = json.loads(args_str) if isinstance(args_str, str) else args_str
+        except json.JSONDecodeError:
+            parsed = {}
+        logging.info("Extracted log_data: %s", pprint.pformat(parsed))
+        return "log_data", parsed.get("records", parsed)
+
+    logging.info("No supported function call found in the response.")
+    return None, None


### PR DESCRIPTION
## Summary
- add `openai_utils` module with API configuration, response generation, and function-call parsing helpers
- replace orchestrator stub with OpenAI-powered completion loop

## Testing
- `python -m py_compile openai_utils.py codex_loop.py && echo py_compile_success`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68925bb75b9c83248a74321a263a5b08