### PR TITLE
Add history tracking and next-step planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Headless Codex Prototype
 
-Prototype exploring a loop between a placeholder "orchestrator" and the ChatGPT Codex site using a headless browser.
+Prototype exploring a loop between a planning LLM and the ChatGPT Codex site using a headless browser.
 
 ## Setup
 
@@ -15,11 +15,11 @@ playwright install
 python codex_loop.py "What is the capital of France?" --cycles 1
 ```
 
-The script performs the following simplified cycle:
+The script performs the following cycle:
 
-1. The orchestrator generates a question (currently a stub).
-2. The question is sent to `https://chatgpt.com/codex` using a headless browser.
-3. The response is extracted from the DOM and printed.
-4. The response is fed back into the orchestrator for the next cycle.
+1. The LLM planner generates the next request for Codex using the user goal and interaction history.
+2. The request is sent to `https://chatgpt.com/codex` using a headless browser.
+3. The Codex response is summarised and appended to the history.
+4. The updated history is provided to the planner to determine the next step.
 
-The number of cycles can be configured via the `--cycles` flag. LLM integration is left as a TODO.
+The number of cycles can be configured via the `--cycles` flag.


### PR DESCRIPTION
## Summary
- Track each Codex interaction with request, response, and LLM-generated summary.
- Use accumulated history to ask the planner LLM for the next Codex request.
- Document the updated orchestration loop and history mechanism.

## Testing
- `python -m py_compile codex_loop.py openai_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68925e0a777883248b5f61124f6381ee