### PR TITLE
Add GUI mode for manual browser interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ playwright install
 python codex_loop.py "What is the capital of France?" --cycles 1
 ```
 
+To interact with the browser during intermediate steps (e.g. solving a
+challenge page), run the scripts with the `--gui` flag. This opens a visible
+browser window and pauses execution so you can complete any required steps
+before the automation resumes.
+
+Example:
+
+```bash
+python codex_login.py --gui
+python codex_loop.py "What is the capital of France?" --cycles 1 --gui
+```
+
 The script performs the following cycle:
 
 1. The LLM planner generates the next request for Codex using the user goal and interaction history.

--- a/codex_login.py
+++ b/codex_login.py
@@ -1,20 +1,22 @@
 import os
 import asyncio
+import argparse
 from playwright.async_api import async_playwright, TimeoutError
 
 LOGIN_URL = "https://chatgpt.com/auth/login?next=/codex"
 
-async def login_to_codex(email: str, password: str) -> None:
+async def login_to_codex(email: str, password: str, gui: bool = False) -> None:
     """Attempt to log into the Codex site using Playwright.
 
     The function navigates to the login page, fills the email and password
-    fields, and submits the form. It prints whether the login appears
-    successful or not. The actual login is expected to fail when invalid
-    credentials are supplied, but this function exercises the DOM flow.
+    fields, and submits the form. In ``gui`` mode the browser window is
+    visible and, if a challenge page (e.g. Cloudflare) is encountered,
+    the routine pauses and allows the user to intervene manually before
+    resuming.
     """
 
     async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
+        browser = await p.chromium.launch(headless=not gui)
         context = await browser.new_context(ignore_https_errors=True)
         page = await context.new_page()
         await page.goto(LOGIN_URL)
@@ -22,9 +24,24 @@ async def login_to_codex(email: str, password: str) -> None:
         try:
             await page.wait_for_selector('input[name="email"]', timeout=30000)
         except TimeoutError:
-            print("Login form not found; perhaps blocked by challenge page.")
-            await browser.close()
-            return
+            if gui:
+                print(
+                    "Login form not found; a challenge page may be present."
+                    "\nResolve it in the browser window, then press Enter here to continue."
+                )
+                await asyncio.get_running_loop().run_in_executor(
+                    None, input, "Press Enter to resume..."
+                )
+                try:
+                    await page.wait_for_selector('input[name="email"]', timeout=30000)
+                except TimeoutError:
+                    print("Login form still not found. Aborting.")
+                    await browser.close()
+                    return
+            else:
+                print("Login form not found; perhaps blocked by challenge page.")
+                await browser.close()
+                return
 
         await page.fill('input[name="email"]', email)
         await page.fill('input[name="password"]', password)
@@ -43,7 +60,20 @@ async def login_to_codex(email: str, password: str) -> None:
 
         await browser.close()
 
-if __name__ == "__main__":
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Log into Codex using Playwright")
+    parser.add_argument(
+        "--gui", action="store_true", help="Open a visible browser and pause for manual steps"
+    )
+    args = parser.parse_args()
+
     email = os.environ.get("CODEX_EMAIL", "user@example.com")
     password = os.environ.get("CODEX_PASSWORD", "not-a-real-password")
-    asyncio.run(login_to_codex(email, password))
+
+    asyncio.run(login_to_codex(email, password, gui=args.gui))
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- allow headless scripts to switch to a visible browser via `--gui`
- pause to let the user solve challenge pages before resuming
- document GUI usage in README

## Testing
- `python -m py_compile codex_login.py codex_loop.py openai_utils.py`
- `python codex_login.py --help`
- `python codex_loop.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6892717ff88c83248e6958b3e3e3566e