### PR TITLE
Add phase mode entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,15 @@ The script performs the following cycle:
 4. The updated history is provided to the planner to determine the next step.
 
 The number of cycles can be configured via the `--cycles` flag.
+
+## Phase mode
+
+Some environments expect an entry point named `phase_mode`. The project
+provides a thin wrapper so these tools can launch the agent directly:
+
+```bash
+python phase_mode.py "What is the capital of France?" --cycles 1
+```
+
+This entry point forwards to the regular `codex_loop` script but offers a
+stable module name for orchestration systems.

--- a/phase_mode.py
+++ b/phase_mode.py
@@ -1,0 +1,10 @@
+"""Phase mode entry point for the Codex agent.
+
+This thin wrapper exists so external tooling can invoke the headless
+Codex loop using a stable module name.
+"""
+
+from codex_loop import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `phase_mode.py` wrapper so orchestration tools can launch the Codex loop with a stable module name.
- Document how to run the new entry point in the README.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689307f16b6c8324892515f42dc0b6d0