### PR TITLE
Add phase_login entry point for Codex login

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ python phase_mode.py "What is the capital of France?" --cycles 1
 
 This entry point forwards to the regular `codex_loop` script but offers a
 stable module name for orchestration systems.
+
+Similarly, the project exposes a `phase_login` module that wraps the
+`codex_login` script so the login workflow can be launched via a predictable
+entry point:
+
+```bash
+python phase_login.py --gui
+```

--- a/phase_login.py
+++ b/phase_login.py
@@ -1,0 +1,10 @@
+"""Phase login entry point for the Codex agent.
+
+This thin wrapper exists so external tooling can invoke the Codex login using a
+stable module name.
+"""
+
+from codex_login import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `phase_login` wrapper to expose Codex login under a stable module name
- document the new login entry point in README

## Testing
- `python -m py_compile codex_login.py codex_loop.py phase_mode.py phase_login.py openai_utils.py`
- `python phase_login.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6894223d1e4c8324a12a7d68ec60cd75